### PR TITLE
Get configuration file from ~/.atom/packages

### DIFF
--- a/lib/touch-bar-utility.js
+++ b/lib/touch-bar-utility.js
@@ -9,6 +9,8 @@ const NotificationManager = atom.notifications;
 const PackageManager = atom.packages;
 const Workspace = atom.workspace;
 
+const packagePath = `${PackageManager.getPackageDirPaths()[0]}/touchbar-utility`;
+
 import {
   TouchBar,
   nativeImage
@@ -121,7 +123,8 @@ export default {
   },
 
   editConfiguration() {
-    Workspace.open('./lib/configuration.js', {})
+    let configPath = `${packagePath}/lib/configuration.js`;
+    Workspace.open(configPath, {})
   }
 
 };


### PR DESCRIPTION
This changes the file opened from the menu item `Packages > TouchBar Utility > Edit configuration` from a local configuration file, to the file located at `~/.atom/packages/touchbar-utility/lib/configuration.js`.