### PR TITLE
Better checking for command existence in dispatchAction()

### DIFF
--- a/lib/dispatchAction.js
+++ b/lib/dispatchAction.js
@@ -8,6 +8,7 @@ const listOfSystemPackages = ['editor', 'pane']
 function dispatchAction(compositeEvent, eventTarget, override) {
   // Target: editor or atom-workspace
 
+  const commandExists = atom.packages.commandRegistry.registeredCommands[compositeEvent];
   let firstSplit = compositeEvent.split(':');
   const atomPackage = firstSplit[0];
   const packageEvent = firstSplit[1];
@@ -29,7 +30,7 @@ function dispatchAction(compositeEvent, eventTarget, override) {
       break;
   }
 
-  if (override) {
+  if (override || commandExists) {
     emitEvent(eventTarget, atomPackage, packageEvent);
     return;
   }


### PR DESCRIPTION
Check the command registry, as it includes built-in packages, as well as
packages that haven't been activated yet (but will automatically activate
when their commands are invoked).

I believe this will fix issues #4, #18, #24, #25, and #26. I was able to revert all `click` handlers to use `clickDispatchAction` instead.